### PR TITLE
feat: #22 - add delete use case

### DIFF
--- a/src/adapter/model/app/signup_process.rs
+++ b/src/adapter/model/app/signup_process.rs
@@ -93,7 +93,187 @@ pub mod verify_email {
     }
 }
 
-//todo add id error maping
+pub mod verification_timed_out {
+    use super::{Id, ParseIdError};
+    use crate::application::usecase::signup_process::verification_timed_out as uc;
+    use std::result;
+    use thiserror::Error;
+
+    pub type Request = uc::Request;
+    pub type Response = uc::Response;
+    pub type Result = result::Result<Response, Error>;
+
+    #[derive(Debug, Error)]
+    pub enum Error {
+        #[error("{}", ParseIdError)]
+        Id,
+        #[error("SignupProcess {0:?} not found")]
+        NotFound(Id),
+        #[error("{}", uc::Error::Repo)]
+        Repo,
+    }
+
+    impl From<uc::Error> for Error {
+        fn from(e: uc::Error) -> Self {
+            match e {
+                uc::Error::Repo => Error::Repo,
+                uc::Error::NotFound(id) => Error::NotFound(id.into()),
+            }
+        }
+    }
+
+    impl From<ParseIdError> for Error {
+        fn from(_: ParseIdError) -> Self {
+            Self::Id
+        }
+    }
+}
+
+pub mod extend_verification_time {
+    use super::{Id, ParseIdError};
+    use crate::application::usecase::signup_process::extend_verification_time as uc;
+    use std::result;
+    use thiserror::Error;
+
+    pub type Request = uc::Request;
+    pub type Response = uc::Response;
+    pub type Result = result::Result<Response, Error>;
+
+    #[derive(Debug, Error)]
+    pub enum Error {
+        #[error("{}", ParseIdError)]
+        Id,
+        #[error("SignupProcess {0:?} not found")]
+        NotFound(Id),
+        #[error("{}", uc::Error::Repo)]
+        Repo,
+    }
+
+    impl From<uc::Error> for Error {
+        fn from(e: uc::Error) -> Self {
+            match e {
+                uc::Error::Repo => Error::Repo,
+                uc::Error::NotFound(id) => Error::NotFound(id.into()),
+            }
+        }
+    }
+
+    impl From<ParseIdError> for Error {
+        fn from(_: ParseIdError) -> Self {
+            Self::Id
+        }
+    }
+}
+
+pub mod completion_timed_out {
+    use super::{Id, ParseIdError};
+    use crate::application::usecase::signup_process::completion_timed_out as uc;
+    use std::result;
+    use thiserror::Error;
+
+    pub type Request = uc::Request;
+    pub type Response = uc::Response;
+    pub type Result = result::Result<Response, Error>;
+
+    #[derive(Debug, Error)]
+    pub enum Error {
+        #[error("{}", ParseIdError)]
+        Id,
+        #[error("SignupProcess {0:?} not found")]
+        NotFound(Id),
+        #[error("{}", uc::Error::Repo)]
+        Repo,
+    }
+
+    impl From<uc::Error> for Error {
+        fn from(e: uc::Error) -> Self {
+            match e {
+                uc::Error::Repo => Error::Repo,
+                uc::Error::NotFound(id) => Error::NotFound(id.into()),
+            }
+        }
+    }
+
+    impl From<ParseIdError> for Error {
+        fn from(_: ParseIdError) -> Self {
+            Self::Id
+        }
+    }
+}
+
+pub mod extend_completion_time {
+    use super::{Id, ParseIdError};
+    use crate::application::usecase::signup_process::extend_completion_time as uc;
+    use std::result;
+    use thiserror::Error;
+
+    pub type Request = uc::Request;
+    pub type Response = uc::Response;
+    pub type Result = result::Result<Response, Error>;
+
+    #[derive(Debug, Error)]
+    pub enum Error {
+        #[error("{}", ParseIdError)]
+        Id,
+        #[error("SignupProcess {0:?} not found")]
+        NotFound(Id),
+        #[error("{}", uc::Error::Repo)]
+        Repo,
+    }
+
+    impl From<uc::Error> for Error {
+        fn from(e: uc::Error) -> Self {
+            match e {
+                uc::Error::Repo => Error::Repo,
+                uc::Error::NotFound(id) => Error::NotFound(id.into()),
+            }
+        }
+    }
+
+    impl From<ParseIdError> for Error {
+        fn from(_: ParseIdError) -> Self {
+            Self::Id
+        }
+    }
+}
+
+pub mod delete {
+    use super::{Id, ParseIdError};
+    use crate::application::usecase::signup_process::delete as uc;
+    use std::result;
+    use thiserror::Error;
+
+    pub type Request = uc::Request;
+    pub type Response = uc::Response;
+    pub type Result = result::Result<Response, Error>;
+
+    #[derive(Debug, Error)]
+    pub enum Error {
+        #[error("{}", ParseIdError)]
+        Id,
+        #[error("SignupProcess {0:?} not found")]
+        NotFound(Id),
+        #[error("{}", uc::Error::Repo)]
+        Repo,
+    }
+
+    impl From<uc::Error> for Error {
+        fn from(e: uc::Error) -> Self {
+            match e {
+                uc::Error::Repo => Error::Repo,
+                uc::Error::NotFound(id) => Error::NotFound(id.into()),
+            }
+        }
+    }
+
+    impl From<ParseIdError> for Error {
+        fn from(_: ParseIdError) -> Self {
+            Self::Id
+        }
+    }
+}
+
+// TODO: add id error maping
 pub mod complete {
     use super::{Id, ParseIdError};
     use crate::application::usecase::signup_process::complete as uc;

--- a/src/application/usecase/signup_process/complete.rs
+++ b/src/application/usecase/signup_process/complete.rs
@@ -79,7 +79,12 @@ where
             self.repo
                 .save_latest_state(process.clone().into())
                 .map_err(|_| Error::NotFound(req.id))?;
-            let user: User = process.into();
+            let user: User = User::new(
+                crate::domain::entity::user::Id::new(req.id),
+                process.email(),
+                process.username(),
+                process.password(),
+            );
             self.user_repo
                 .save(user.clone().into())
                 .map_err(|_| Error::Repo)?;

--- a/src/application/usecase/signup_process/delete.rs
+++ b/src/application/usecase/signup_process/delete.rs
@@ -1,0 +1,86 @@
+use crate::{
+    application::gateway::repository::signup_process::{GetError, Repo, SaveError},
+    domain::entity::signup_process::{
+        CompletionTimedOut, Id, SignupProcess, SignupStateEnum, VerificationTimedOut,
+    },
+};
+
+use thiserror::Error;
+
+#[derive(Debug)]
+pub struct Request {
+    pub id: Id,
+}
+
+#[derive(Debug)]
+pub struct Response {
+    pub id: Id,
+}
+pub struct Delete<'r, R> {
+    repo: &'r R,
+}
+
+impl<'r, R> Delete<'r, R> {
+    pub fn new(repo: &'r R) -> Self {
+        Self { repo }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("SignupProcess {0} not found")]
+    NotFound(Id),
+    #[error("{}", SaveError::Connection)]
+    Repo,
+}
+
+impl From<SaveError> for Error {
+    fn from(err: SaveError) -> Self {
+        match err {
+            SaveError::Connection => Self::Repo,
+        }
+    }
+}
+
+impl From<(GetError, Id)> for Error {
+    fn from((err, id): (GetError, Id)) -> Self {
+        match err {
+            GetError::NotFound => Self::NotFound(id),
+            GetError::Connection => Self::Repo,
+        }
+    }
+}
+
+impl<'r, R> Delete<'r, R>
+where
+    R: Repo,
+{
+    /// Create a new user with the given name.
+    pub fn exec(&self, req: Request) -> Result<Response, Error> {
+        log::debug!("SignupProcess scheduled for deletion: {:?}", req);
+        let record = self
+            .repo
+            .get_latest_state(req.id)
+            .map_err(|err| (err, req.id))?;
+        let process = match record.state {
+            SignupStateEnum::VerificationTimedOut { .. } => {
+                match SignupProcess::<VerificationTimedOut>::try_from(record) {
+                    Ok(process) => process.delete(),
+                    Err(_) => return Err((GetError::NotFound, req.id).into()),
+                }
+            }
+            SignupStateEnum::CompletionTimedOut { .. } => {
+                match SignupProcess::<CompletionTimedOut>::try_from(record) {
+                    Ok(process) => process.delete(),
+                    Err(_) => return Err((GetError::NotFound, req.id).into()),
+                }
+            }
+            _ => return Err((GetError::NotFound, req.id).into()),
+        };
+
+        self.repo
+            .save_latest_state(process.into())
+            .map_err(|_| Error::NotFound(req.id))?;
+        Ok(Response { id: req.id })
+    }
+}

--- a/src/application/usecase/signup_process/mod.rs
+++ b/src/application/usecase/signup_process/mod.rs
@@ -1,5 +1,6 @@
 pub mod complete;
 pub mod completion_timed_out;
+pub mod delete;
 pub mod extend_completion_time;
 pub mod extend_verification_time;
 pub mod initialize;

--- a/src/domain/entity/user.rs
+++ b/src/domain/entity/user.rs
@@ -1,7 +1,5 @@
 use crate::domain::value_object;
 
-use super::signup_process::{Completed, Idable, SignupProcess};
-
 pub type Id = value_object::Id<User>;
 pub type UserName = value_object::UserName<User>;
 pub type Email = value_object::Email<User>;
@@ -45,17 +43,6 @@ impl User {
     }
     pub const fn password(&self) -> &Password {
         &self.password
-    }
-}
-
-impl From<SignupProcess<Completed>> for User {
-    fn from(signup_process: SignupProcess<Completed>) -> Self {
-        Self {
-            id: Id::new(signup_process.id()),
-            email: signup_process.email(),
-            username: signup_process.username(),
-            password: signup_process.password(),
-        }
     }
 }
 


### PR DESCRIPTION
- added delete use case
- added missing adapter/model/app/signup_process pub mod re-exports
- moved SignupProcess<Complete> -> User logic from domain::enity::signup_process to application::use_cases::signup_process::complete