### PR TITLE
feat: add JSON boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ version = "0.1.0"
 dependencies = [
  "ca-application",
  "ca-domain",
+ "serde",
  "thiserror",
 ]
 
@@ -109,6 +110,7 @@ dependencies = [
  "ca-domain",
  "chrono",
  "log",
+ "serde",
  "thiserror",
 ]
 
@@ -118,6 +120,19 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "rstest",
+ "serde",
+ "uuid",
+]
+
+[[package]]
+name = "ca-infrastructure-boundary-json"
+version = "0.1.0"
+dependencies = [
+ "ca-adapter",
+ "ca-application",
+ "ca-domain",
+ "serde",
+ "serde_json",
  "uuid",
 ]
 
@@ -242,6 +257,7 @@ dependencies = [
  "ca-adapter",
  "ca-application",
  "ca-domain",
+ "ca-infrastructure-boundary-json",
  "ca-infrastructure-boundary-string",
  "ca-infrastructure-interface-cli",
  "ca-infrastructure-persistance-json_file",
@@ -808,10 +824,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 
 [[bin]]
-name = "clean-arch"
+name = "clean-arch-cli-json-file"
 path = "src/bin/cli-json-file.rs"
 
 [workspace]
@@ -17,6 +17,7 @@ members = [
     "crates/application",
     "crates/domain",
     "crates/infrastructure/boundary/string",
+    "crates/infrastructure/boundary/json",
     "crates/infrastructure/interface/cli",
     "crates/infrastructure/persistance/json_file",
     "crates/infrastructure/service/email/file",
@@ -34,6 +35,7 @@ rust-version = "1.81.0"
 # Workspace dependencies
 ca-infrastructure-service-email-file = { version = "0.1.0", path = "crates/infrastructure/service/email/file" }
 ca-infrastructure-boundary-string = { version = "0.1.0", path = "crates/infrastructure/boundary/string" }
+ca-infrastructure-boundary-json = { version = "0.1.0", path = "crates/infrastructure/boundary/json" }
 ca-infrastructure-interface-cli = { version = "0.1.0", path = "crates/infrastructure/interface/cli" }
 ca-infrastructure-persistance-json_file = { version = "0.1.0", path = "crates/infrastructure/persistance/json_file" }
 ca-domain = { version = "0.1.0", path = "crates/domain" }

--- a/crates/infrastructure/boundary/json/Cargo.toml
+++ b/crates/infrastructure/boundary/json/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ca-infrastructure-boundary-json"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+# Workspace dependencies
+ca-adapter = { version = "=0.1.0", path = "../../../adapter" }
+ca-application = { version = "=0.1.0", path = "../../../application" }
+ca-domain = { version = "=0.1.0", path = "../../../domain" }
+
+# External dependencies
+uuid = { version = "1.16.0", features = ["v4"] }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = { version = "1.0.140", features = ["preserve_order"] }
+
+[dev-dependencies]

--- a/crates/infrastructure/boundary/json/src/ingester.rs
+++ b/crates/infrastructure/boundary/json/src/ingester.rs
@@ -1,0 +1,27 @@
+use ca_adapter::boundary::{Error, Ingester, UsecaseRequestResult};
+use ca_application::{
+    gateway::{
+        EmailVerificationServiceProvider, SignupProcessIdGenProvider, SignupProcessRepoProvider,
+        TokenRepoProvider, UserRepoProvider,
+    },
+    usecase::Usecase,
+};
+use serde_json::Value;
+
+use super::Boundary;
+
+impl<'d, D, U: Usecase<'d, D>> Ingester<'d, D, U> for Boundary
+where
+    D: SignupProcessRepoProvider
+        + SignupProcessIdGenProvider
+        + UserRepoProvider
+        + TokenRepoProvider
+        + EmailVerificationServiceProvider,
+{
+    type InputModel = Value;
+    fn ingest(data: Self::InputModel) -> UsecaseRequestResult<'d, D, U> {
+        let data: <U as Usecase<'d, D>>::Request =
+            serde_json::from_value(data).map_err(|_e| Error::ParseInputError)?;
+        Ok(data)
+    }
+}

--- a/crates/infrastructure/boundary/json/src/lib.rs
+++ b/crates/infrastructure/boundary/json/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod ingester;
+pub mod presenter;
+
+#[derive(Debug, Clone)]
+pub struct Boundary;

--- a/crates/infrastructure/boundary/json/src/presenter.rs
+++ b/crates/infrastructure/boundary/json/src/presenter.rs
@@ -1,0 +1,25 @@
+use ca_adapter::boundary::{Presenter, UsecaseResponseResult};
+use ca_application::{
+    gateway::{
+        EmailVerificationServiceProvider, SignupProcessIdGenProvider, SignupProcessRepoProvider,
+        TokenRepoProvider, UserRepoProvider,
+    },
+    usecase::Usecase,
+};
+use serde_json::{json, Value};
+
+use super::Boundary;
+
+impl<'d, D, U: Usecase<'d, D>> Presenter<'d, D, U> for Boundary
+where
+    D: SignupProcessRepoProvider
+        + SignupProcessIdGenProvider
+        + UserRepoProvider
+        + TokenRepoProvider
+        + EmailVerificationServiceProvider,
+{
+    type ViewModel = Value;
+    fn present(data: UsecaseResponseResult<'d, D, U>) -> Self::ViewModel {
+        json!(data)
+    }
+}


### PR DESCRIPTION
**Description:**
Adds the JSON boundary crate named `ca-infrastructure-boundary-json`

**Changes:**
- added `infrastructure/boundary/json` crate.
- implemented `Ingester` and `Presenter` traits for said `Boundary`.
- updated workspace and `Cargo.toml` dependencies accordingly.

**closes:** #51