### PR TITLE
feat: add CLI JSON interface and binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ca-infrastructure-interface-cli-json"
+version = "0.1.0"
+dependencies = [
+ "ca-adapter",
+ "ca-application",
+ "ca-infrastructure-boundary-json",
+ "clap",
+ "serde_json",
+]
+
+[[package]]
 name = "ca-infrastructure-persistance-json_file"
 version = "0.1.0"
 dependencies = [
@@ -260,6 +271,7 @@ dependencies = [
  "ca-infrastructure-boundary-json",
  "ca-infrastructure-boundary-string",
  "ca-infrastructure-interface-cli",
+ "ca-infrastructure-interface-cli-json",
  "ca-infrastructure-persistance-json_file",
  "ca-infrastructure-service-email-file",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ publish = false
 name = "clean-arch-cli-json-file"
 path = "src/bin/cli-json-file.rs"
 
+[[bin]]
+name = "clean-arch-cli-json-json-file"
+path = "src/bin/cli-json-json-file.rs"
+
 [workspace]
 members = [
     "crates/adapter",
@@ -19,10 +23,10 @@ members = [
     "crates/infrastructure/boundary/string",
     "crates/infrastructure/boundary/json",
     "crates/infrastructure/interface/cli",
+    "crates/infrastructure/interface/cli-json",
     "crates/infrastructure/persistance/json_file",
     "crates/infrastructure/service/email/file",
 ]
-exclude = ["crates/web-app"]
 
 [workspace.package]
 authors = ["Filip Dulic <filip.dulic@gmail.com>"]
@@ -37,6 +41,7 @@ ca-infrastructure-service-email-file = { version = "0.1.0", path = "crates/infra
 ca-infrastructure-boundary-string = { version = "0.1.0", path = "crates/infrastructure/boundary/string" }
 ca-infrastructure-boundary-json = { version = "0.1.0", path = "crates/infrastructure/boundary/json" }
 ca-infrastructure-interface-cli = { version = "0.1.0", path = "crates/infrastructure/interface/cli" }
+ca-infrastructure-interface-cli-json = { version = "0.1.0", path = "crates/infrastructure/interface/cli-json" }
 ca-infrastructure-persistance-json_file = { version = "0.1.0", path = "crates/infrastructure/persistance/json_file" }
 ca-domain = { version = "0.1.0", path = "crates/domain" }
 ca-application = { version = "0.1.0", path = "crates/application" }

--- a/crates/adapter/src/boundary.rs
+++ b/crates/adapter/src/boundary.rs
@@ -7,8 +7,8 @@ use ca_application::usecase::Usecase;
 pub enum Error<'d, D, U: Usecase<'d, D>> {
     #[error("Unable to parse id")]
     ParseIdError,
-    #[error("Unable to parse input")]
-    ParseInputError,
+    #[error("Unable to parse input {0}")]
+    ParseInputError(String),
     #[error("Usecase error {0:?}")]
     UsecaseError(U::Error),
 }

--- a/crates/infrastructure/boundary/json/src/ingester.rs
+++ b/crates/infrastructure/boundary/json/src/ingester.rs
@@ -21,7 +21,7 @@ where
     type InputModel = Value;
     fn ingest(data: Self::InputModel) -> UsecaseRequestResult<'d, D, U> {
         let data: <U as Usecase<'d, D>>::Request =
-            serde_json::from_value(data).map_err(|_e| Error::ParseInputError)?;
+            serde_json::from_value(data).map_err(|e| Error::ParseInputError(e.to_string()))?;
         Ok(data)
     }
 }

--- a/crates/infrastructure/boundary/string/src/ingester/signup_process.rs
+++ b/crates/infrastructure/boundary/string/src/ingester/signup_process.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use uuid::Uuid;
 
 use super::super::Boundary;
@@ -30,7 +32,7 @@ where
     fn ingest(input: Self::InputModel) -> UsecaseRequestResult<'d, D, Complete<'d, D>> {
         let (id, username, password) = input;
         id.parse()
-            .map_err(|_| Error::ParseInputError)
+            .map_err(|e: <Uuid as FromStr>::Err| Error::ParseInputError(e.to_string()))
             .map(|uuid: Uuid| CompleteRequest {
                 id: Id::from(uuid),
                 username,
@@ -47,7 +49,7 @@ where
     fn ingest(input: Self::InputModel) -> UsecaseRequestResult<'d, D, ExtendCompletionTime<'d, D>> {
         input
             .parse()
-            .map_err(|_| Error::ParseInputError)
+            .map_err(|e: <Uuid as FromStr>::Err| Error::ParseInputError(e.to_string()))
             .map(|uuid: Uuid| ExtendCompletionTimeRequest { id: Id::from(uuid) })
     }
 }
@@ -62,7 +64,7 @@ where
     ) -> UsecaseRequestResult<'d, D, ExtendVerificationTime<'d, D>> {
         input
             .parse()
-            .map_err(|_| Error::ParseInputError)
+            .map_err(|e: <Uuid as FromStr>::Err| Error::ParseInputError(e.to_string()))
             .map(|uuid: Uuid| ExtendVerificationTimeRequest { id: Id::from(uuid) })
     }
 }
@@ -75,7 +77,7 @@ where
     fn ingest(input: Self::InputModel) -> UsecaseRequestResult<'d, D, GetStateChain<'d, D>> {
         input
             .parse()
-            .map_err(|_| Error::ParseInputError)
+            .map_err(|e: <Uuid as FromStr>::Err| Error::ParseInputError(e.to_string()))
             .map(|uuid: Uuid| GetStateChainRequest { id: Id::from(uuid) })
     }
 }
@@ -100,7 +102,7 @@ where
     ) -> UsecaseRequestResult<'d, D, SendVerificationEmail<'d, D>> {
         input
             .parse()
-            .map_err(|_| Error::ParseInputError)
+            .map_err(|e: <Uuid as FromStr>::Err| Error::ParseInputError(e.to_string()))
             .map(|uuid: Uuid| SendVerificationEmailRequest { id: Id::from(uuid) })
     }
 }
@@ -113,7 +115,7 @@ where
     fn ingest(input: Self::InputModel) -> UsecaseRequestResult<'d, D, VerifyEmail<'d, D>> {
         let (id, token) = input;
         id.parse()
-            .map_err(|_| Error::ParseInputError)
+            .map_err(|e: <Uuid as FromStr>::Err| Error::ParseInputError(e.to_string()))
             .map(|uuid: Uuid| VerifyEmailRequest {
                 id: Id::from(uuid),
                 token,
@@ -129,7 +131,7 @@ where
     fn ingest(input: Self::InputModel) -> UsecaseRequestResult<'d, D, Delete<'d, D>> {
         input
             .parse()
-            .map_err(|_| Error::ParseInputError)
+            .map_err(|e: <Uuid as FromStr>::Err| Error::ParseInputError(e.to_string()))
             .map(|uuid: Uuid| DeleteRequest { id: Id::from(uuid) })
     }
 }

--- a/crates/infrastructure/boundary/string/src/ingester/user.rs
+++ b/crates/infrastructure/boundary/string/src/ingester/user.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use uuid::Uuid;
 
 use ca_adapter::boundary::{Error, Ingester, UsecaseRequestResult};
@@ -22,7 +24,7 @@ where
     fn ingest(input: Self::InputModel) -> UsecaseRequestResult<'d, D, Delete<'d, D>> {
         input
             .parse()
-            .map_err(|_| Error::ParseInputError)
+            .map_err(|e: <Uuid as FromStr>::Err| Error::ParseInputError(e.to_string()))
             .map(|uuid: Uuid| DeleteRequest { id: Id::from(uuid) })
     }
 }
@@ -35,7 +37,7 @@ where
     fn ingest(input: Self::InputModel) -> UsecaseRequestResult<'d, D, Update<'d, D>> {
         let (id, email, username, password) = input;
         id.parse()
-            .map_err(|_| Error::ParseInputError)
+            .map_err(|e: <Uuid as FromStr>::Err| Error::ParseInputError(e.to_string()))
             .map(|uuid: Uuid| UpdateRequest {
                 id: Id::from(uuid),
                 email,
@@ -53,7 +55,7 @@ where
     fn ingest(input: Self::InputModel) -> UsecaseRequestResult<'d, D, GetOne<'d, D>> {
         input
             .parse()
-            .map_err(|_| Error::ParseInputError)
+            .map_err(|e: <Uuid as FromStr>::Err| Error::ParseInputError(e.to_string()))
             .map(|uuid: Uuid| GetOneRequest { id: Id::from(uuid) })
     }
 }

--- a/crates/infrastructure/interface/cli-json/Cargo.toml
+++ b/crates/infrastructure/interface/cli-json/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ca-infrastructure-interface-cli-json"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+
+# Workspace dependencies
+ca-adapter = { version = "=0.1.0", path = "../../../adapter" }
+ca-application = { version = "=0.1.0", path = "../../../application" }
+ca-infrastructure-boundary-json = { version = "=0.1.0", path = "../../boundary/json" }
+
+# External dependencies
+clap = { version = "4.5.35", features = ["derive"] }
+serde_json = { version = "1.0.140", features = ["preserve_order"] }

--- a/crates/infrastructure/interface/cli-json/src/lib.rs
+++ b/crates/infrastructure/interface/cli-json/src/lib.rs
@@ -1,0 +1,137 @@
+//! This module contains the CLI interface for the application.
+//!
+//! Handles command-line interface (CLI) interactions. It defines the commands
+//! that the CLI can execute and maps them to the appropriate actions within
+//! the application. This file typically uses a library like clap to parse and
+//! handle command-line arguments.
+//!
+//! Key Responsibilities:
+//! * Command Definition: Define the various commands that the CLI can handle.
+//! * Command Parsing: Use a library like clap to parse the command-line arguments
+//!     and match them to the defined commands.
+//! * Command Execution: Map the parsed commands to the appropriate functions or
+//!     methods in the application.
+use std::sync::Arc;
+
+use clap::Subcommand;
+
+use ca_adapter::{controller::Controller, dependency_provider::Transactional};
+use ca_application::usecase::{
+    signup_process::{
+        complete::Complete, delete::Delete, extend_completion_time::ExtendCompletionTime,
+        extend_verification_time::ExtendVerificationTime, get_state_chain::GetStateChain,
+        initialize::Initialize, send_verification_email::SendVerificationEmail,
+        verify_email::VerifyEmail,
+    },
+    user::{delete::Delete as UserDelete, get_all::GetAll, get_one::GetOne, update::Update},
+};
+
+use ca_infrastructure_boundary_json as boundary;
+
+//use crate::boundary::string::
+#[derive(Subcommand)]
+pub enum Command {
+    #[clap(about = "Initialize signup process", alias = "sp-init")]
+    InitializeSignupProcess { request: String },
+    #[clap(
+        about = "Send verification email for signup process",
+        alias = "sp-send-verify"
+    )]
+    SendVerificationEmail { request: String },
+    #[clap(
+        about = "Extend verification time of signup process",
+        alias = "sp-extend-verify"
+    )]
+    ExtendVerificationTimeOfSignupProcess { request: String },
+    #[clap(
+        about = "Extend completion time of signup process",
+        alias = "sp-extend-complete"
+    )]
+    ExtendCompletionTimeOfSignupProcess { request: String },
+    #[clap(about = "Delete signup process", alias = "sp-delete")]
+    DeleteSignupProcess { request: String },
+    #[clap(about = "Verify Email of signup process", alias = "sp-verify")]
+    VerifyEmailOfSignupProcess { request: String },
+    #[clap(about = "Complete signup process", alias = "sp-complete")]
+    CompleteSignupProcess { request: String },
+    #[clap(about = "Get state chain for signup process", alias = "sp-chain")]
+    GetStateChain { request: String },
+    #[clap(about = "List all users")]
+    ListUsers { request: String },
+    #[clap(about = "Read user")]
+    ReadUser { request: String },
+    #[clap(about = "Update user")]
+    UpdateUser { request: String },
+    #[clap(about = "Delete user")]
+    DeleteUser { request: String },
+}
+
+pub fn run<D>(db: Arc<D>, cmd: Command)
+where
+    D: Transactional,
+{
+    let app_controller = Controller::<D, boundary::Boundary>::new(db);
+
+    match cmd {
+        Command::InitializeSignupProcess { request } => {
+            let request = serde_json::from_str(&request).expect("Failed to parse request");
+            let res = app_controller.handle_usecase::<Initialize<D>>(request);
+            println!("{res}");
+        }
+        Command::SendVerificationEmail { request } => {
+            let request = serde_json::from_str(&request).expect("Failed to parse request");
+            let res = app_controller.handle_usecase::<SendVerificationEmail<D>>(request);
+            println!("{res}");
+        }
+        Command::ExtendVerificationTimeOfSignupProcess { request } => {
+            let request = serde_json::from_str(&request).expect("Failed to parse request");
+            let res = app_controller.handle_usecase::<ExtendVerificationTime<D>>(request);
+            println!("{res}");
+        }
+        Command::ExtendCompletionTimeOfSignupProcess { request } => {
+            let request = serde_json::from_str(&request).expect("Failed to parse request");
+            let res = app_controller.handle_usecase::<ExtendCompletionTime<D>>(request);
+            println!("{res}");
+        }
+        Command::DeleteSignupProcess { request } => {
+            let request = serde_json::from_str(&request).expect("Failed to parse request");
+            let res = app_controller.handle_usecase::<Delete<D>>(request);
+            println!("{res}");
+        }
+        Command::VerifyEmailOfSignupProcess { request } => {
+            let request = serde_json::from_str(&request).expect("Failed to parse request");
+            let res = app_controller.handle_usecase::<VerifyEmail<D>>(request);
+            println!("{res}");
+        }
+        Command::CompleteSignupProcess { request } => {
+            let request = serde_json::from_str(&request).expect("Failed to parse request");
+            let res = app_controller.handle_usecase::<Complete<D>>(request);
+            println!("{res}");
+        }
+        Command::GetStateChain { request } => {
+            let request = serde_json::from_str(&request).expect("Failed to parse request");
+            let res = app_controller.handle_usecase::<GetStateChain<D>>(request);
+            println!("{res}");
+        }
+        Command::ListUsers { request } => {
+            let request = serde_json::from_str(&request).expect("Failed to parse request");
+            let res = app_controller.handle_usecase::<GetAll<D>>(request);
+            println!("{res}");
+        }
+        Command::DeleteUser { request } => {
+            let request = serde_json::from_str(&request).expect("Failed to parse request");
+            let res = app_controller.handle_usecase::<UserDelete<D>>(request);
+            println!("{res}");
+        }
+        Command::ReadUser { request } => {
+            let request = serde_json::from_str(&request).expect("Failed to parse request");
+            let res = app_controller.handle_usecase::<GetOne<D>>(request);
+            println!("{res}");
+        }
+        Command::UpdateUser { request } => {
+            let request = serde_json::from_str(&request).expect("Failed to parse request");
+            let res = app_controller.handle_usecase::<Update<D>>(request);
+            println!("{res}");
+        }
+    }
+}

--- a/src/bin/cli-json-json-file.rs
+++ b/src/bin/cli-json-json-file.rs
@@ -1,0 +1,117 @@
+use ca_adapter::dependency_provider::Transactional;
+use ca_application::gateway::service::email::EmailVerificationService;
+use ca_application::gateway::{
+    EmailVerificationServiceProvider, SignupProcessIdGenProvider, SignupProcessRepoProvider,
+    TokenRepoProvider, UserIdGenProvider, UserRepoProvider,
+};
+use ca_application::identifier::NewId;
+use ca_application::usecase::Comitable;
+use ca_domain::entity::{signup_process::Id as SignupProcessId, user::Id as UserId};
+use ca_infrastructure_interface_cli_json as cli;
+use ca_infrastructure_persistance_json_file::utils::{data_storage, data_storage_directory};
+use ca_infrastructure_persistance_json_file::JsonFile;
+use ca_infrastructure_service_email_file::FileEmailService;
+use clap::Parser;
+use std::{path::PathBuf, sync::Arc};
+
+#[derive(Parser)]
+struct Args {
+    #[clap(subcommand)]
+    command: cli::Command,
+    #[clap(help = "Directory to store data ", long)]
+    data_dir: Option<PathBuf>,
+}
+
+struct DependancyProvider {
+    db: JsonFile,
+    email_verification_servuce: FileEmailService,
+}
+
+impl DependancyProvider {
+    fn new(db: JsonFile, email_verification_servuce: FileEmailService) -> Self {
+        Self {
+            db,
+            email_verification_servuce,
+        }
+    }
+}
+
+impl SignupProcessIdGenProvider for DependancyProvider {
+    fn signup_process_id_gen(&self) -> &dyn NewId<SignupProcessId> {
+        &self.db
+    }
+}
+
+impl SignupProcessRepoProvider for DependancyProvider {
+    fn signup_process_repo(
+        &self,
+    ) -> &dyn ca_application::gateway::repository::signup_process::Repo {
+        &self.db
+    }
+}
+
+impl UserIdGenProvider for DependancyProvider {
+    fn user_id_gen(&self) -> &dyn NewId<UserId> {
+        &self.db
+    }
+}
+
+impl UserRepoProvider for DependancyProvider {
+    fn user_repo(&self) -> &dyn ca_application::gateway::repository::user::Repo {
+        &self.db
+    }
+}
+
+impl TokenRepoProvider for DependancyProvider {
+    fn token_repo(&self) -> &dyn ca_application::gateway::repository::token::Repo {
+        &self.db
+    }
+}
+
+impl Clone for DependancyProvider {
+    fn clone(&self) -> Self {
+        Self {
+            db: self.db.clone(),
+            email_verification_servuce: self.email_verification_servuce.clone(),
+        }
+    }
+}
+
+impl EmailVerificationServiceProvider for DependancyProvider {
+    fn email_verification_service(&self) -> &dyn EmailVerificationService {
+        &self.email_verification_servuce
+    }
+}
+
+impl Transactional for DependancyProvider {
+    // TODO: implement a proper transaction
+    fn run_in_transaction<'d, F, R, E>(&'d self, f: F) -> Result<R, E>
+    where
+        Result<R, E>: Into<Comitable<R, E>>,
+        F: FnOnce(&'d Self) -> Result<R, E>,
+    {
+        let res = f(self);
+        match res.into() {
+            Comitable::Commit(inner) => {
+                println!("Commiting");
+                inner
+            }
+            Comitable::Rollback(inner) => {
+                println!("Rolling Back");
+                inner
+            }
+        }
+    }
+}
+
+pub fn main() -> Result<(), std::io::Error> {
+    let args = Args::parse();
+    let email_folder = data_storage_directory(None);
+    let email_verification_servuce = FileEmailService::try_new(email_folder)?;
+    let dep_provider = Arc::new(DependancyProvider::new(
+        data_storage(args.data_dir),
+        email_verification_servuce,
+    ));
+    cli::run(dep_provider, args.command);
+    Ok(())
+}


### PR DESCRIPTION
- added `infrastructure/interface/cli-json` crate.
- implemented CLI commands with JSON input parsing.
- updated workspace, `Cargo.toml`, and dependencies accordingly.
- updated `ParseInputError` to accept a `String` for a error message.

closes #63