### PR TITLE
refactor: separate dependancy provider form `Transactional` trait

### DIFF
--- a/crates/adapter/src/controller.rs
+++ b/crates/adapter/src/controller.rs
@@ -1,6 +1,9 @@
 use std::{marker::PhantomData, sync::Arc};
 
-use ca_application::usecase::{Comitable, Usecase};
+use ca_application::{
+    gateway::AuthExtractorProvider,
+    usecase::{Comitable, Usecase},
+};
 use ca_domain::entity::auth_context::AuthError;
 
 use super::{
@@ -16,7 +19,7 @@ pub struct Controller<D, B> {
 
 impl<'d, D, B> Controller<D, B>
 where
-    D: 'd + Transactional,
+    D: 'd + Transactional + AuthExtractorProvider,
 {
     pub const fn new(dependency_provider: Arc<D>) -> Self {
         Self {

--- a/crates/adapter/src/dependency_provider.rs
+++ b/crates/adapter/src/dependency_provider.rs
@@ -1,23 +1,6 @@
-use ca_application::{
-    gateway::{
-        AuthExtractorProvider, AuthPackerProvider, EmailVerificationServiceProvider,
-        SignupProcessIdGenProvider, SignupProcessRepoProvider, TokenRepoProvider,
-        UserIdGenProvider, UserRepoProvider,
-    },
-    usecase::Comitable,
-};
+use ca_application::usecase::Comitable;
 
-pub trait Transactional:
-    Clone
-    + SignupProcessRepoProvider
-    + SignupProcessIdGenProvider
-    + UserRepoProvider
-    + UserIdGenProvider
-    + EmailVerificationServiceProvider
-    + TokenRepoProvider
-    + AuthPackerProvider
-    + AuthExtractorProvider
-{
+pub trait Transactional: Clone {
     fn run_in_transaction<'d, F, R, E>(&'d self, f: F) -> Result<R, E>
     where
         Result<R, E>: Into<Comitable<R, E>>,

--- a/crates/infrastructure/interface/cli-json/src/lib.rs
+++ b/crates/infrastructure/interface/cli-json/src/lib.rs
@@ -16,16 +16,22 @@ use std::sync::Arc;
 use clap::Subcommand;
 
 use ca_adapter::{controller::Controller, dependency_provider::Transactional};
-use ca_application::usecase::{
-    signup_process::{
-        complete::Complete, delete::Delete, extend_completion_time::ExtendCompletionTime,
-        extend_verification_time::ExtendVerificationTime, get_state_chain::GetStateChain,
-        initialize::Initialize, send_verification_email::SendVerificationEmail,
-        verify_email::VerifyEmail,
+use ca_application::{
+    gateway::{
+        AuthExtractorProvider, AuthPackerProvider, EmailVerificationServiceProvider,
+        SignupProcessIdGenProvider, SignupProcessRepoProvider, TokenRepoProvider, UserRepoProvider,
     },
-    user::{
-        delete::Delete as UserDelete, get_all::GetAll, get_one::GetOne, login::Login,
-        update::Update,
+    usecase::{
+        signup_process::{
+            complete::Complete, delete::Delete, extend_completion_time::ExtendCompletionTime,
+            extend_verification_time::ExtendVerificationTime, get_state_chain::GetStateChain,
+            initialize::Initialize, send_verification_email::SendVerificationEmail,
+            verify_email::VerifyEmail,
+        },
+        user::{
+            delete::Delete as UserDelete, get_all::GetAll, get_one::GetOne, login::Login,
+            update::Update,
+        },
     },
 };
 
@@ -112,7 +118,14 @@ pub enum Command {
 
 pub fn run<D>(db: Arc<D>, cmd: Command)
 where
-    D: Transactional,
+    D: Transactional
+        + SignupProcessIdGenProvider
+        + SignupProcessRepoProvider
+        + UserRepoProvider
+        + EmailVerificationServiceProvider
+        + TokenRepoProvider
+        + AuthPackerProvider
+        + AuthExtractorProvider,
 {
     let app_controller = Controller::<D, boundary::Boundary>::new(db);
 

--- a/crates/infrastructure/interface/cli/src/lib.rs
+++ b/crates/infrastructure/interface/cli/src/lib.rs
@@ -16,16 +16,22 @@ use std::sync::Arc;
 use clap::Subcommand;
 
 use ca_adapter::{controller::Controller, dependency_provider::Transactional};
-use ca_application::usecase::{
-    signup_process::{
-        complete::Complete, delete::Delete, extend_completion_time::ExtendCompletionTime,
-        extend_verification_time::ExtendVerificationTime, get_state_chain::GetStateChain,
-        initialize::Initialize, send_verification_email::SendVerificationEmail,
-        verify_email::VerifyEmail,
+use ca_application::{
+    gateway::{
+        AuthExtractorProvider, AuthPackerProvider, EmailVerificationServiceProvider,
+        SignupProcessIdGenProvider, SignupProcessRepoProvider, TokenRepoProvider, UserRepoProvider,
     },
-    user::{
-        delete::Delete as UserDelete, get_all::GetAll, get_one::GetOne, login::Login,
-        update::Update,
+    usecase::{
+        signup_process::{
+            complete::Complete, delete::Delete, extend_completion_time::ExtendCompletionTime,
+            extend_verification_time::ExtendVerificationTime, get_state_chain::GetStateChain,
+            initialize::Initialize, send_verification_email::SendVerificationEmail,
+            verify_email::VerifyEmail,
+        },
+        user::{
+            delete::Delete as UserDelete, get_all::GetAll, get_one::GetOne, login::Login,
+            update::Update,
+        },
     },
 };
 
@@ -91,7 +97,14 @@ pub enum Command {
 
 pub fn run<D>(db: Arc<D>, cmd: Command)
 where
-    D: Transactional,
+    D: Transactional
+        + SignupProcessIdGenProvider
+        + SignupProcessRepoProvider
+        + UserRepoProvider
+        + EmailVerificationServiceProvider
+        + TokenRepoProvider
+        + AuthPackerProvider
+        + AuthExtractorProvider,
 {
     let app_controller = Controller::<D, string::Boundary>::new(db);
 


### PR DESCRIPTION
- Split dependency traits from `Transactional` in `adapter/src/dependency_provider.rs` to enhance adapter crate universality.
- Propagate dependency traits to `interfaces` in `infrastructure`.
- Keep `AuthExtractorProvider` in `Controller` as it's used to extract `AuthClaims`.